### PR TITLE
Set `physics.velocity_threshold` to 100.0

### DIFF
--- a/game.project
+++ b/game.project
@@ -27,3 +27,5 @@ input_method = HiddenInputField
 [physics]
 gravity_y = -1000.0
 scale = 0.01
+velocity_threshold = 100.0
+


### PR DESCRIPTION
This commit https://github.com/defold/defold/commit/3aa72b50354fc7763a7fdaa26b1f7ee3041a2cc2 in the engine introduced a breaking change in 2D physics (only if the project had custom physics scale like this) - `velocity threshold` depends on the `physics.scale` parameter. If you set scale 0.01, you have to set velocity threshold to 100 to set it to 1 m/s internally (a default Box2D value, actually) to avoid jittering of bodies at low velocities.

This template has the scale for physics 0.01, but does not have a corresponding value in velocity threshold and therefore, in my opinion, can be very confusing and frustrating with “physics bugs” for a novice developer.
